### PR TITLE
Make appLinks optional

### DIFF
--- a/Sources/LinksKit/Model/LinkSection.swift
+++ b/Sources/LinksKit/Model/LinkSection.swift
@@ -143,13 +143,15 @@ extension LinkSection {
    ///     developerLinks: LinkSection.developerSocialLinks(platforms: [.twitter, .github], handle: "YourDevHandle")
    /// )
    /// ```
-   public static func socialMenus(appLinks: LinkSection, developerLinks: LinkSection) -> Self {
+   public static func socialMenus(appLinks: LinkSection? = nil, developerLinks: LinkSection) -> Self {
       LinkSection(
          title: String(localized: "Social Links", bundle: .module),
          entries: [
-            .menu(LinkMenu(title: "Follow the App", systemImage: "app.badge", linkSections: [appLinks])),
-            .menu(LinkMenu(title: "Follow the Developer", systemImage: "person", linkSections: [developerLinks])),
-         ]
+            appLinks.map { links in
+               LinkSection.Entry.menu(LinkMenu( title: "Follow the App", systemImage: "app.badge", linkSections: [links]))
+            },
+            .menu(LinkMenu(title: "Follow the Developer", systemImage: "person", linkSections: [developerLinks]))
+         ].compactMap { $0 }
       )
    }
 


### PR DESCRIPTION
## Proposed Changes

  - As a developer I might want to add social links to my developer profiles but I might not have a social profile for the specific app, so it would be nice if appLinks in the socialMenus is optional
