### PR TITLE
Downgraded package Swift version tools to 5.9, so LinksKit's usable on Xcode 15

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 5.9
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
It's all in the title. Package still works fine.