### PR TITLE
Add instance to bluesky similar to mastodon

### DIFF
--- a/Sources/LinksKit/Model/SocialPlatform.swift
+++ b/Sources/LinksKit/Model/SocialPlatform.swift
@@ -4,7 +4,7 @@ import Foundation
 ///
 /// Use this enum to specify social media platforms when configuring social links in LinksKit.
 public enum SocialPlatform: Hashable {
-   case bluesky
+   case bluesky(instance: String)
    case facebook
    case github
    case instagram
@@ -36,7 +36,7 @@ public enum SocialPlatform: Hashable {
 
    func url(handle: String) -> URL {
       switch self {
-      case .bluesky: URL(string: "https://bsky.app/profile/\(handle)")!
+      case .bluesky(let instance): URL(string: "https://bsky.app/profile/\(handle).\(instance)")!
       case .facebook: URL(string: "https://facebook.com/\(handle)")!
       case .github: URL(string: "https://github.com/\(handle)")!
       case .instagram: URL(string: "https://instagram.com/\(handle)")!


### PR DESCRIPTION
Fixes #

Since bluesky is a decentralized network similar to mastodon, just based on another protocol called [atproto](https://atproto.com/), it should have the option to specify an instance like mastodon. Because my handle is n0rthk1n9 for example and my instance is the main one bsky.social. So currently you'd have to set the handle parameter to n0rthk1n9.bsky.social to make the created link working. For that reason I added a way to specify the instance to the Bluesky enum case.
